### PR TITLE
Fix cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+**Bugfixes:**
+
+- Fix an issue that causes the plugin to change cwd (e.g. in a monorepo setup)
+
 ## 1.3.0
 
 **Improvements:**

--- a/autoload/rescript.vim
+++ b/autoload/rescript.vim
@@ -29,16 +29,16 @@ function! rescript#UpdateProjectEnv()
   let l:res_bin_dir = finddir('node_modules/bs-platform/', ".;") . s:rescript_arch
 
   "if !exists("g:rescript_compile_exe")
-  let g:rescript_compile_exe = l:res_bin_dir . "/bsc.exe"
+  let g:rescript_compile_exe = getcwd() . "/" . l:res_bin_dir . "/bsc.exe"
   "endif
 
   "if !exists("g:rescript_build_exe")
-  let g:rescript_build_exe = l:res_bin_dir . "/bsb.exe"
+  let g:rescript_build_exe = getcwd() . "/" . l:res_bin_dir . "/bsb.exe"
   "endif
 
   " Note that this doesn't find bsconfig when the editor was started without a
   " specific file within the project
-  let g:rescript_project_config = findfile("bsconfig.json", ".;")
+  let g:rescript_project_config = getcwd() . "/" . findfile("bsconfig.json", ".;")
 
   " Try to find the nearest .git folder instead
   if g:rescript_project_config == ""
@@ -48,7 +48,7 @@ function! rescript#UpdateProjectEnv()
   endif
 
   " Make sure that our local working directory is in the rescript_project_root
-  exe "lcd " . g:rescript_project_root
+  "exe "lcd " . g:rescript_project_root
 endfunction
 
 " Inits the plugin variables, e.g. finding all the plugin related binaries
@@ -93,7 +93,9 @@ function! rescript#DetectVersion()
   call rescript#UpdateProjectEnv()
   let l:command = g:rescript_compile_exe . " -version"
 
+  exe "lcd " . g:rescript_project_root
   silent let l:output = system(l:command)
+  exe "lcd -"
 
   let l:version_list = matchlist(l:output, '.* \([0-9]\+\.[0-9]\+\.[0-9]\+.*\) (.*')
 
@@ -134,7 +136,9 @@ function! rescript#Format()
   " bsc -format myFile.res > tempfile
   let l:command = g:rescript_compile_exe . " -color never -format " . l:tmpname . " 2> " . l:stderr_tmpname
 
+  exe "lcd " . g:rescript_project_root
   silent let l:out = systemlist(l:command) 
+  exe "lcd -"
 
   let l:stderr = readfile(l:stderr_tmpname)
 
@@ -398,7 +402,9 @@ function! rescript#BuildProject(...)
     let l:cmd = g:rescript_build_exe . " " . a:1
   endif
 
+  exe "lcd " . g:rescript_project_root
   let out = system(l:cmd)
+  exe "lcd -"
 
   " We don't rely too heavily on exit codes. If there's a compiler.log,
   " then there is either an error or a warning, so we rely on the existence
@@ -492,7 +498,6 @@ function! rescript#ReasonToRescript()
     echo "Could not reformat Reason file to ReScript"
   endif
 endfunction
-
 
 function! rescript#Info()
   let l:version = "ReScript version: " . rescript#DetectVersion()

--- a/test/fixtures/compiler/compiler-log.exp
+++ b/test/fixtures/compiler/compiler-log.exp
@@ -1,4 +1,4 @@
-/Users/ryyppy/Projects/reason-association/vim-rescript/src/foo.res:12:6 -> [E] (Syntax) Did you forget a `=` here?
+/Users/rescript/Projects/vim-rescript/src/foo.res:12:6 -> [E] (Syntax) Did you forget a `=` here?
 /Users/rescript/Projects/vim-rescript/src/Text.res:47:11 -> [W] (Warning 20) deprecated: Pervasives.string_of_float Please use something else, otherwise we can't do much about it
 /Users/rescript/Projects/vim-rescript/src/Button.res:50:58 -> [E] This has type: list<t> Somewhere wanted: string => int
 /Users/rescript/Projects/vim-rescript/src/Json.res:20:11 -> [W] (Warning 3) deprecated: Pervasives.string_of_float Please use Js.Float.toString instead, string_of_float generates unparseable floats

--- a/test/fixtures/compiler/compiler-log.txt
+++ b/test/fixtures/compiler/compiler-log.txt
@@ -1,7 +1,7 @@
 #Start(1402242571131)
 
   Syntax error!
-  /Users/ryyppy/Projects/reason-association/vim-rescript/src/foo.res:12:6
+  /Users/rescript/Projects/vim-rescript/src/foo.res:12:6
 
   10 │ let f = "test"
   11 │

--- a/test/test_all.vim
+++ b/test/test_all.vim
@@ -38,8 +38,8 @@ function! InitTest()
     let l:platform = "linux"
   endif
 
-  call assert_equal("node_modules/bs-platform/" . l:platform . "/bsc.exe", g:rescript_compile_exe)
-  call assert_equal("node_modules/bs-platform/" . l:platform . "/bsb.exe", g:rescript_build_exe)
+  call assert_equal(getcwd() . "/node_modules/bs-platform/" . l:platform . "/bsc.exe", g:rescript_compile_exe)
+  call assert_equal(getcwd() . "/node_modules/bs-platform/" . l:platform . "/bsb.exe", g:rescript_build_exe)
 endfunction
 
 function FormatErrorTest(fixtureName,...)


### PR DESCRIPTION
This fixes #30 and #25 

To test this change, please do the following:

**In your vimrc, add a branch specific plug instruction:**

```viml
Plug 'rescript-lang/vim-rescript', {'branch': 'fix-cwd'}
```

After adding the instruction, `:so %` your `vimrc` and then run `:PlugUpdate`. From here on, you can test if the cwd issue still persists.

Use `:RescriptInfo` to get details about the current environment and detected project paths.
